### PR TITLE
Jason implement move interface

### DIFF
--- a/Assets/EditModeTests/TestSuite.cs
+++ b/Assets/EditModeTests/TestSuite.cs
@@ -9,46 +9,50 @@ namespace Tests
 {
     public class TestSuite
     {
-public class MovementTests
-    {
-        [UnityTest]
-        public IEnumerator CanJump()
+        public class MovementTests
         {
-            EditorSceneManager.OpenScene("Assets/Scenes/SampleScene.unity");
+            [UnityTest]
+            public IEnumerator CanJump()
+            {
+                EditorSceneManager.OpenScene("Assets/Scenes/SampleScene.unity");
 
-            new WaitForSeconds(1);
+                new WaitForSeconds(1);
 
-            var player = GameObject.Find("Player");
+                var player = GameObject.Find("Player");
 
-            Debug.Log(player);
+                Debug.Log(player);
 
-            //get initial place
-            var initialHeight = player.transform.position.y;
+                //get initial place
+                var initialHeight = player.transform.position.y;
+                Debug.Log($@"initial height: {initialHeight}");
 
-            //press space
-            //requires interface...
+                //press space
+                var script = player.GetComponent<Platformer>();
+                script.pressingJump = true;
 
-            //allow time to pass, for part of jump to happen
-            new WaitForSeconds(0.1f);
+                //allow time to pass, for part of jump to happen
+                new WaitForSeconds(0.5f);
 
-            //player should be higher
-            Assert.True(player.transform.position.y > initialHeight);
+                //player should be higher
+                var newHeight = player.transform.position.y;
+                Debug.Log($@"new height: {newHeight}");
+                Assert.True(newHeight > initialHeight);
 
-            yield return null;
+                yield return null;
+            }
+
+            [UnityTest]
+            public IEnumerator TurnSpeedTest()
+            {
+                yield return null;
+            }
+
+            [TearDown]
+            public void AfterEveryTest()
+            {
+                //foreach (var object in GameObject.Find(everything))
+                //{Object.Destroy(object)}
+            }
         }
-
-        [UnityTest]
-        public IEnumerator TurnSpeedTest()
-        {
-            yield return null;
-        }
-
-        [TearDown]
-        public void AfterEveryTest()
-        {
-            //foreach (var object in GameObject.Find(everything))
-            //{Object.Destroy(object)}
-        }
-    }
     }
 }

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -178,8 +178,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6940c010b2867a44850b751613a4f4b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _rigidbody: {fileID: 0}
   _groundBumper: {fileID: 1587468495}
-  _baseSpeed: 2
+  _baseSpeed: 5
   _maxSpeed: 10
   _baseJumps: 2
   _jumpsRemaining: 0
@@ -189,6 +190,9 @@ MonoBehaviour:
   _distanceToMidair: 0.05
   _lastTimeGrounded: 0
   _groundedForgivenessTime: 0.1
+  pressingRight: 0
+  pressingLeft: 0
+  pressingJump: 0
   groundLayer:
     serializedVersion: 2
     m_Bits: 8192

--- a/Assets/Scripts/Platformer.cs
+++ b/Assets/Scripts/Platformer.cs
@@ -136,9 +136,9 @@ public class Platformer : MonoBehaviour
 
     void Jump()
     {
-        Debug.Log($"jump function entered. pressing jump debug bool: {pressingJump}");
+        //Debug.Log($"jump function entered. pressing jump debug bool: {pressingJump}");
         bool tryingToJump = pressingJump == false ? Input.GetKeyDown(KeyCode.Space) : true;
-        Debug.Log($"trying to jump: {tryingToJump}");
+        //Debug.Log($"trying to jump: {tryingToJump}");
 
         if (CanJump && tryingToJump)
         {

--- a/Assets/Scripts/Platformer.cs
+++ b/Assets/Scripts/Platformer.cs
@@ -11,12 +11,12 @@ using UnityEngine;
 public class Platformer : MonoBehaviour
 {
     // physical components
-    new Rigidbody2D rigidbody;
+    public Rigidbody2D _rigidbody;
     [SerializeField] Transform _groundBumper;
 
     // stats
     [SerializeField] float _baseSpeed;
-    [SerializeField] float _maxSpeed;
+    [SerializeField] public float _maxSpeed;
     [SerializeField] int _baseJumps;
     [SerializeField] int _jumpsRemaining;
     [SerializeField] float _jumpMultiplier;
@@ -45,14 +45,14 @@ public class Platformer : MonoBehaviour
     {
         get
         {
-            return rigidbody.velocity.y < 0;
+            return _rigidbody.velocity.y < 0;
         }
     }
     public bool IsRising
     {
         get
         {
-            return rigidbody.velocity.y > 0;
+            return _rigidbody.velocity.y > 0;
         }
     }
     public bool HasGoodFooting
@@ -84,7 +84,7 @@ public class Platformer : MonoBehaviour
 
     void Start()
     {
-        rigidbody = GetComponent<Rigidbody2D>();
+        _rigidbody = GetComponent<Rigidbody2D>();
         _jumpsRemaining = _baseJumps;
     }
 
@@ -102,7 +102,7 @@ public class Platformer : MonoBehaviour
     void Move()
     {
         //Debug.Log($"x movement before applying move: {rigidbody.velocity.x}");
-        float startingXMovement = rigidbody.velocity.x;
+        float startingXMovement = _rigidbody.velocity.x;
         
         float xDirection = pressingRight == false ? (pressingLeft == false ? Input.GetAxisRaw("Horizontal") : -1) : 1;
         //Debug.Log($"x direction: {xDirection}");
@@ -128,7 +128,7 @@ public class Platformer : MonoBehaviour
             xMovement = xMovementWithMomentum;
         }
 
-        rigidbody.velocity = new Vector2(xMovement, rigidbody.velocity.y);
+        _rigidbody.velocity = new Vector2(xMovement, _rigidbody.velocity.y);
         //Debug.Log($"x movement after applying move: {rigidbody.velocity}");
 
         Jump();
@@ -142,11 +142,11 @@ public class Platformer : MonoBehaviour
 
         if (CanJump && tryingToJump)
         {
-            rigidbody.velocity = new Vector2(rigidbody.velocity.x, _leapDistance);
+            _rigidbody.velocity = new Vector2(_rigidbody.velocity.x, _leapDistance);
             _jumpBegan = Time.time;
             _jumpsRemaining--;
         }
-        if (IsFalling) rigidbody.velocity += Physics2D.gravity * Time.deltaTime;
-        else if (IsRising && !tryingToJump) rigidbody.velocity += Vector2.up * Physics2D.gravity * Time.deltaTime * _jumpMultiplier;
+        if (IsFalling) _rigidbody.velocity += Physics2D.gravity * Time.deltaTime;
+        else if (IsRising && !tryingToJump) _rigidbody.velocity += Vector2.up * Physics2D.gravity * Time.deltaTime * _jumpMultiplier;
     }
 }

--- a/Assets/Scripts/Platformer.cs
+++ b/Assets/Scripts/Platformer.cs
@@ -27,6 +27,11 @@ public class Platformer : MonoBehaviour
     [SerializeField] float _lastTimeGrounded;
     [SerializeField] float _groundedForgivenessTime;
 
+    // Debug Variables
+    public bool pressingRight = false;
+    public bool pressingLeft = false;
+    public bool pressingJump = false;
+
     // Is Functions
     public bool IsGrounded
     {
@@ -99,7 +104,7 @@ public class Platformer : MonoBehaviour
         //Debug.Log($"x movement before applying move: {rigidbody.velocity.x}");
         float startingXMovement = rigidbody.velocity.x;
         
-        float xDirection = Input.GetAxisRaw("Horizontal");
+        float xDirection = pressingRight == false ? (pressingLeft == false ? Input.GetAxisRaw("Horizontal") : -1) : 1;
         //Debug.Log($"x direction: {xDirection}");
         float xDesiredMovement = xDirection * _baseSpeed;
         //Debug.Log($"xDesiredMovement: {xDesiredMovement}");
@@ -131,7 +136,9 @@ public class Platformer : MonoBehaviour
 
     void Jump()
     {
-        bool tryingToJump = Input.GetKeyDown(KeyCode.Space);
+        Debug.Log($"jump function entered. pressing jump debug bool: {pressingJump}");
+        bool tryingToJump = pressingJump == false ? Input.GetKeyDown(KeyCode.Space) : true;
+        Debug.Log($"trying to jump: {tryingToJump}");
 
         if (CanJump && tryingToJump)
         {

--- a/Assets/Tests/HelloTest.cs
+++ b/Assets/Tests/HelloTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+using UnityEngine.SceneManagement;
 
 namespace Tests
 {
@@ -42,5 +43,50 @@ namespace Tests
         }
 
         //void RetryAction()
+    }
+
+    public class MovementTests
+    {
+        [UnityTest]
+        public IEnumerator CanJump()
+        {
+            SceneManager.LoadScene("Assets/Scenes/SampleScene.unity");
+
+            yield return new WaitForSeconds(0.1f);
+
+            var player = GameObject.Find("Player");
+
+            //get initial place
+            var initialHeight = player.transform.position.y;
+            Debug.Log($@"initial height: {initialHeight}");
+            yield return new WaitForSeconds(0.1f);
+
+            //press space
+            var script = player.GetComponent<Platformer>();
+            script.pressingJump = true;
+
+            //allow time to pass, for part of jump to happen
+            yield return new WaitForSeconds(0.2f);
+
+            //player should be higher
+            var newHeight = player.transform.position.y;
+            Debug.Log($@"new height: {newHeight}");
+            Assert.True(newHeight > initialHeight);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator TurnSpeedTest()
+        {
+            yield return null;
+        }
+
+        [TearDown]
+        public void AfterEveryTest()
+        {
+            //foreach (var object in GameObject.Find(everything))
+            //{Object.Destroy(object)}
+        }
     }
 }

--- a/Assets/Tests/HelloTest.cs
+++ b/Assets/Tests/HelloTest.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.SceneManagement;
+using System;
 
 namespace Tests
 {
@@ -72,14 +73,40 @@ namespace Tests
             var newHeight = player.transform.position.y;
             Debug.Log($@"new height: {newHeight}");
             Assert.True(newHeight > initialHeight);
-
-            yield return null;
         }
 
         [UnityTest]
         public IEnumerator TurnSpeedTest()
         {
+            SceneManager.LoadScene("Assets/Scenes/SampleScene.unity");
+
+            yield return new WaitForSeconds(0.1f);
+
+            var player = GameObject.Find("Player");
+            var script = player.GetComponent<Platformer>();
+            //move to the right, full speed, for a few frames
+            script.pressingRight = true;
+            script._rigidbody.velocity = new Vector2(script._maxSpeed, 0);
+            yield return new WaitForSeconds(0.2f);
+            
+            //get initial place
+            var positionBeforeChange = player.transform.position.x;
+            Debug.Log($@"position before movement is swapped: {positionBeforeChange}");
+            script.pressingRight = false;
+            script.pressingLeft = true;
+
+            //wait one frame
             yield return null;
+            
+            //we've just changed momentum, but how much?
+            var positionAfterChange = player.transform.position.x;
+            Debug.Log($@"position after movement is swapped: {positionAfterChange}");
+
+            var differenceInChange = Math.Abs(positionAfterChange - positionBeforeChange);
+            Debug.Log($@"difference from before and after change: {differenceInChange}");
+
+            //player's momentum shouldn't be too strong
+            Assert.True(differenceInChange < 0.11f);
         }
 
         [TearDown]


### PR DESCRIPTION
Merge this pull request first.

-ignore testsuite.cs, I think a follow-on pull request clears out testsuite.cs, it's for edit mode tests and there's not much justification for it, hellotest.cs is where most of our tests should go.
-added bools in platformer.cs that the tests use to manipulate the player, adding logic to allow for this
-implemented two tests in HelloTest.cs: one makes the player jump, then checks that there's vertical movement. The other move the character at full speed to the right, then changes direction, and makes sure the movement isn't too floaty.